### PR TITLE
add SSE circuit breaker and reactive polling fallback

### DIFF
--- a/src/app/features/notification/models/notification.state.ts
+++ b/src/app/features/notification/models/notification.state.ts
@@ -15,7 +15,9 @@ export enum SseConnectionStatus {
   CONNECTING = 'CONNECTING',
   CONNECTED = 'CONNECTED',
   RECONNECTING = 'RECONNECTING',
-  ERROR = 'ERROR'
+  ERROR = 'ERROR',
+  /** Circuit open: max reconnect attempts reached. Polling takes over; SSE probed every 2 min. */
+  CIRCUIT_OPEN = 'CIRCUIT_OPEN'
 }
 
 // =============================================================================

--- a/src/app/features/notification/services/notification-sse.service.ts
+++ b/src/app/features/notification/services/notification-sse.service.ts
@@ -43,8 +43,10 @@ export class NotificationSseService {
   private readonly maxReconnectAttempts = 10;
   private readonly baseReconnectDelay = 1000;  // 1 second
   private readonly maxReconnectDelay = 30000;  // 30 seconds
+  private readonly probeDelay = 120000;         // 2 min between half-open probes
   private reconnectAttempts = 0;
   private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+  private probeTimeout: ReturnType<typeof setTimeout> | null = null;
 
   // Event subjects
   private readonly _statusChange = new Subject<SseConnectionStatus>();
@@ -67,6 +69,10 @@ export class NotificationSseService {
 
   get isConnected(): boolean {
     return this._currentStatus === SseConnectionStatus.CONNECTED;
+  }
+
+  get isCircuitOpen(): boolean {
+    return this._currentStatus === SseConnectionStatus.CIRCUIT_OPEN;
   }
 
   // ===========================================================================
@@ -103,6 +109,7 @@ export class NotificationSseService {
     console.log('[SSE] Disconnecting');
 
     this.clearReconnectTimeout();
+    this.clearProbeTimeout();
 
     if (this.eventSource) {
       this.eventSource.close();
@@ -205,8 +212,8 @@ export class NotificationSseService {
 
   private scheduleReconnect(): void {
     if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-      console.error('[SSE] Max reconnection attempts reached');
-      this.updateStatus(SseConnectionStatus.ERROR);
+      console.warn('[SSE] Max reconnect attempts reached — opening circuit');
+      this.openCircuit();
       return;
     }
 
@@ -227,10 +234,35 @@ export class NotificationSseService {
     }, delay);
   }
 
+  private openCircuit(): void {
+    this.updateStatus(SseConnectionStatus.CIRCUIT_OPEN);
+    this.scheduleProbe();
+  }
+
+  private scheduleProbe(): void {
+    this.clearProbeTimeout();
+    console.log(`[SSE] Circuit open — probing in ${this.probeDelay / 1000}s`);
+
+    this.probeTimeout = setTimeout(() => {
+      if (this._currentStatus === SseConnectionStatus.CIRCUIT_OPEN) {
+        console.log('[SSE] Half-open probe attempt');
+        this.reconnectAttempts = 0;
+        this.connect();
+      }
+    }, this.probeDelay);
+  }
+
   private clearReconnectTimeout(): void {
     if (this.reconnectTimeout) {
       clearTimeout(this.reconnectTimeout);
       this.reconnectTimeout = null;
+    }
+  }
+
+  private clearProbeTimeout(): void {
+    if (this.probeTimeout) {
+      clearTimeout(this.probeTimeout);
+      this.probeTimeout = null;
     }
   }
 

--- a/src/app/features/notification/services/notification.facade.ts
+++ b/src/app/features/notification/services/notification.facade.ts
@@ -2,7 +2,7 @@
 
 import { Injectable, inject, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import {Observable, tap, catchError, throwError, finalize, of, map, Subscription, interval, switchMap} from 'rxjs';
+import {Observable, tap, catchError, throwError, finalize, of, map, Subscription, interval, switchMap, EMPTY, startWith} from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { NotificationStore } from '../state/notification.store';
 import { NotificationApiService } from './notification-api.service';
@@ -43,7 +43,8 @@ export class NotificationFacade {
   private initialized = false;
 
   private pollingSubscription: Subscription | null = null;
-  private readonly POLLING_INTERVAL_MS = 60000; // 60 secondes
+  private readonly POLLING_INTERVAL_MS = 60000;   // 60s — SSE down but reconnecting
+  private readonly INTENSIVE_POLLING_MS = 30000;  // 30s — circuit open, SSE fully dead
 
   // ===========================================================================
   // EXPOSED STATE (readonly signals from store)
@@ -65,6 +66,7 @@ export class NotificationFacade {
   readonly sseStatus = this.store.sseStatus;
   readonly isConnected = this.store.isConnected;
   readonly isReconnecting = this.store.isReconnecting;
+  readonly isCircuitOpen = this.store.isCircuitOpen;
 
   // UI State
   readonly isLoading = this.store.isLoading;
@@ -509,19 +511,28 @@ export class NotificationFacade {
 // ===========================================================================
 
   /**
-   * Starts polling for unread count as a fallback mechanism.
-   * This ensures the badge stays updated even if SSE fails.
+   * Starts polling as a fallback when SSE is unavailable.
+   *
+   * - CONNECTED     → no polling (EMPTY)
+   * - RECONNECTING  → poll every 60s (light backup)
+   * - CIRCUIT_OPEN  → poll every 30s (intensive fallback, SSE fully dead)
+   *
+   * Polling rate adjusts automatically when SSE status changes.
    */
   private startBackupPolling(): void {
     this.stopPolling();
 
-    console.log('[NotificationFacade] Starting backup polling every', this.POLLING_INTERVAL_MS / 1000, 'seconds');
-
-    this.pollingSubscription = interval(this.POLLING_INTERVAL_MS)
+    this.pollingSubscription = this.sse.statusChange$
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        // Ne poll que si SSE n'est PAS connecté (optionnel - enlever cette ligne pour toujours poll)
-        filter(() => !this.sse.isConnected),
+        startWith(this.sse.currentStatus),
+        switchMap(status => {
+          if (status === SseConnectionStatus.CONNECTED) return EMPTY;
+          const ms = status === SseConnectionStatus.CIRCUIT_OPEN
+            ? this.INTENSIVE_POLLING_MS
+            : this.POLLING_INTERVAL_MS;
+          console.log(`[NotificationFacade] Polling every ${ms / 1000}s (SSE: ${status})`);
+          return interval(ms);
+        }),
         switchMap(() => this.api.getUnreadCount().pipe(
           catchError(err => {
             console.warn('[NotificationFacade] Polling error:', err);
@@ -529,18 +540,12 @@ export class NotificationFacade {
           })
         ))
       )
-      .subscribe({
-        next: (response) => {
-          const currentCount = this.store.state().unreadCount;
-
-          if (response.count !== currentCount) {
-            console.log('[NotificationFacade] 🔔 Backup polling detected change:', currentCount, '→', response.count);
-            this.store.setUnreadCount(response.count);
-
-            if (response.count > currentCount) {
-              this.loadRecentNotifications();
-            }
-          }
+      .subscribe(response => {
+        const current = this.store.state().unreadCount;
+        if (response.count !== current) {
+          console.log('[NotificationFacade] 🔔 Polling detected change:', current, '→', response.count);
+          this.store.setUnreadCount(response.count);
+          if (response.count > current) this.loadRecentNotifications();
         }
       });
   }

--- a/src/app/features/notification/state/notification.store.ts
+++ b/src/app/features/notification/state/notification.store.ts
@@ -120,6 +120,11 @@ export class NotificationStore {
     this._state().sseStatus === SseConnectionStatus.RECONNECTING
   );
 
+  /** SSE circuit is open (max retries exhausted, polling takes over) */
+  readonly isCircuitOpen = computed(() =>
+    this._state().sseStatus === SseConnectionStatus.CIRCUIT_OPEN
+  );
+
   /** Has pending toasts */
   readonly hasToasts = computed(() =>
     this._state().toastQueue.length > 0 || this._state().currentToast !== null


### PR DESCRIPTION
- add CIRCUIT_OPEN status to SseConnectionStatus enum
- open circuit after 10 failed reconnect attempts, probe every 2 min (half-open)
- replace static backup polling with reactive polling based on SSE status: CONNECTED → no polling, RECONNECTING → 60s, CIRCUIT_OPEN → 30s
- expose isCircuitOpen signal in store and facade